### PR TITLE
Dev f layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "eslint": "8.27.0",
         "eslint-config-next": "13.0.3",
         "next": "13.0.3",
+        "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint": "8.27.0",
     "eslint-config-next": "13.0.3",
     "next": "13.0.3",
+    "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }

--- a/src/layouts/DashboardLayout.js
+++ b/src/layouts/DashboardLayout.js
@@ -21,7 +21,7 @@ export default function DashboardLayout({ children }) {
                 }}
               >
       
-                <Main>{children}</Main>
+                {children}
               </Box>
             </>
           );

--- a/src/layouts/DashboardLayout.js
+++ b/src/layouts/DashboardLayout.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+// @mui
+import { Box } from '@mui/material';
+import Header from './header';
+DashboardLayout.propTypes = {
+    children: PropTypes.node,
+};
+
+export default function DashboardLayout({ children }) {
+
+    const renderContent = () => {
+        return (
+            <>
+              <Header  />
+      
+              <Box
+                sx={{
+                  display: { lg: 'flex' },
+                  minHeight: { lg: 1 },
+                }}
+              >
+      
+                <Main>{children}</Main>
+              </Box>
+            </>
+          );
+    }
+
+    return renderContent();
+}

--- a/src/layouts/header/Header.js
+++ b/src/layouts/header/Header.js
@@ -37,7 +37,7 @@ export default function Header({ onOpenNav }) {
         sx={{
           boxShadow: 'none',
           height: HEADER.H_MOBILE,
-          width: `calc(100% - ${NAV.W_DASHBOARD + 1}px)`,
+          width: `100%`,
           height: HEADER.H_DASHBOARD_DESKTOP,
         }}
       >

--- a/src/layouts/header/Header.js
+++ b/src/layouts/header/Header.js
@@ -1,0 +1,54 @@
+
+import PropTypes from 'prop-types';
+// @mui
+import { Stack, AppBar, Toolbar, Button } from '@mui/material';
+
+Header.propTypes = {
+    onOpenNav: PropTypes.func,
+  };
+const HEADER = {
+    H_MOBILE: 64,
+    H_MAIN_DESKTOP: 88,
+    H_DASHBOARD_DESKTOP: 92,
+    H_DASHBOARD_DESKTOP_OFFSET: 92 - 32,
+  };
+const NAV = {
+    W_BASE: 260,
+    W_DASHBOARD: 280,
+    W_DASHBOARD_MINI: 88,
+    //
+    H_DASHBOARD_ITEM: 48,
+    H_DASHBOARD_ITEM_SUB: 36,
+    //
+    H_DASHBOARD_ITEM_HORIZONTAL: 32,
+};
+
+export default function Header({ onOpenNav }) {
+    const renderContent = (
+        <>
+    
+          <Stack flexGrow={1} direction="row" alignItems="center" justifyContent="flex-end" spacing={{ xs: 0.5, sm: 1.5 }}>
+            <Button >This is a NAV button</Button>
+          </Stack>
+        </>
+      );
+    return (
+      <AppBar
+        sx={{
+          boxShadow: 'none',
+          height: HEADER.H_MOBILE,
+          width: `calc(100% - ${NAV.W_DASHBOARD + 1}px)`,
+          height: HEADER.H_DASHBOARD_DESKTOP,
+        }}
+      >
+        <Toolbar
+          sx={{
+            height: 1,
+            px: { lg: 5 },
+          }}
+        >
+          {renderContent}
+        </Toolbar>
+      </AppBar>
+    );
+  }

--- a/src/layouts/header/index.js
+++ b/src/layouts/header/index.js
@@ -1,0 +1,1 @@
+export { default } from './Header';

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,0 +1,1 @@
+export {default} from './DashboardLayout'

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,7 +1,11 @@
 import '../../styles/globals.css'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  const getLayout = Component.getLayout ?? ((page) => page);
+  
+  return (
+    getLayout(<Component {...pageProps} />)
+  )
 }
 
 export default MyApp

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,8 @@
 import Head from 'next/head'
 import Image from 'next/image'
 import styles from '../../styles/Home.module.css'
+import DashboardLayout from '../layouts/DashboardLayout'
+Home.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
 
 export default function Home() {
   return (


### PR DESCRIPTION
Added basic layouts for React. 

Includes a Header which is the width of the page. 

Layouts available in the main Dashboard Layouts file. 

This can be used in pages by accessing the dashboard layout component in layouts and using react getLayouts

an example
`Home.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;`
